### PR TITLE
Changed gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 *.exe
-temp.cpp
-temp2.cpp
-tempCodeRunnerFile.cpp
+temp*.cpp


### PR DESCRIPTION
### Replaced temp files list with `temp*.cpp`. 

- File name must start from `temp` and needs to end with `.cpp`.
- In between that any number of characters are allowed.